### PR TITLE
画像解析の速度改善

### DIFF
--- a/backend/app/services/gemini_service.py
+++ b/backend/app/services/gemini_service.py
@@ -201,6 +201,7 @@ class GeminiService:
                     response_mime_type="application/json",
                     response_schema=StepDetail,
                     temperature=self.temperature,
+                    thinking_config=types.ThinkingConfig(thinking_level="low"),
                 )
             )
             


### PR DESCRIPTION
画像解析時のGeminiのthink_levelを`low`にすることで、速度を改善した。
効果:
- 速度: 約60s -> 約5s
- 精度: ほぼ変わらない。若干赤枠がズレることがある程度。